### PR TITLE
Add Cobbler repo support

### DIFF
--- a/cobbler/provider.go
+++ b/cobbler/provider.go
@@ -36,6 +36,7 @@ func Provider() terraform.ResourceProvider {
 			"cobbler_distro":         resourceDistro(),
 			"cobbler_kickstart_file": resourceKickstartFile(),
 			"cobbler_profile":        resourceProfile(),
+			"cobbler_repo":           resourceRepo(),
 			"cobbler_snippet":        resourceSnippet(),
 			"cobbler_system":         resourceSystem(),
 		},

--- a/cobbler/resource_cobbler_repo.go
+++ b/cobbler/resource_cobbler_repo.go
@@ -104,9 +104,8 @@ func resourceRepo() *schema.Resource {
 			},
 
 			"yumopts": &schema.Schema{
-				Type:     schema.TypeList,
+				Type:     schema.TypeMap,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
 				Computed: true,
 			},
 		},
@@ -209,9 +208,13 @@ func buildRepo(d *schema.ResourceData, meta interface{}) cobbler.Repo {
 		rpmList = append(rpmList, i.(string))
 	}
 
-	yumOpts := []string{}
-	for _, i := range d.Get("yum_opts").([]interface{}) {
-		yumOpts = append(yumOpts, i.(string))
+	yumOpts := make(map[string]interface{})
+	y := d.Get("yum_opts")
+	if y != nil {
+		m := y.(map[string]interface{})
+		for k, v := range m {
+			yumOpts[k] = v
+		}
 	}
 
 	repo := cobbler.Repo{

--- a/cobbler/resource_cobbler_repo.go
+++ b/cobbler/resource_cobbler_repo.go
@@ -103,11 +103,11 @@ func resourceRepo() *schema.Resource {
 				Computed: true,
 			},
 
-			"yumopts": &schema.Schema{
-				Type:     schema.TypeMap,
-				Optional: true,
-				Computed: true,
-			},
+			//"yumopts": &schema.Schema{
+			//	Type:     schema.TypeMap,
+			//	Optional: true,
+			//	Computed: true,
+			//},
 		},
 	}
 }
@@ -154,7 +154,7 @@ func resourceRepoRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("owners", repo.Owners)
 	d.Set("proxy", repo.Proxy)
 	d.Set("rpm_list", repo.RpmList)
-	d.Set("yumopts", repo.YumOpts)
+	//d.Set("yumopts", repo.YumOpts)
 
 	return nil
 }
@@ -208,14 +208,14 @@ func buildRepo(d *schema.ResourceData, meta interface{}) cobbler.Repo {
 		rpmList = append(rpmList, i.(string))
 	}
 
-	yumOpts := make(map[string]interface{})
-	y := d.Get("yum_opts")
-	if y != nil {
-		m := y.(map[string]interface{})
-		for k, v := range m {
-			yumOpts[k] = v
-		}
-	}
+	//yumOpts := make(map[string]interface{})
+	//y := d.Get("yum_opts")
+	//if y != nil {
+	//	m := y.(map[string]interface{})
+	//	for k, v := range m {
+	//		yumOpts[k] = v
+	//	}
+	//}
 
 	repo := cobbler.Repo{
 		AptComponents:   aptComponents,
@@ -232,7 +232,7 @@ func buildRepo(d *schema.ResourceData, meta interface{}) cobbler.Repo {
 		Owners:          owners,
 		Proxy:           d.Get("proxy").(string),
 		RpmList:         rpmList,
-		YumOpts:         yumOpts,
+		//YumOpts:         yumOpts,
 	}
 
 	return repo

--- a/cobbler/resource_cobbler_repo.go
+++ b/cobbler/resource_cobbler_repo.go
@@ -1,0 +1,236 @@
+package cobbler
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	cobbler "github.com/jtopjian/cobblerclient"
+)
+
+func resourceRepo() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceRepoCreate,
+		Read:   resourceRepoRead,
+		Update: resourceRepoUpdate,
+		Delete: resourceRepoDelete,
+
+		Schema: map[string]*schema.Schema{
+			"apt_components": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+
+			"apt_dists": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+
+			"arch": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+
+			"breed": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"comment": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"createrepo_flags": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"environment": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"keep_updated": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+
+			"mirror": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"mirror_locally": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"owners": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+
+			"proxy": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"rpm_list": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+
+			"yumopts": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceRepoCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	// Create a cobblerclient.Repo
+	repo := buildRepo(d, config)
+
+	// Attempte to create the Repo
+	log.Printf("[DEBUG] Cobbler Repo: Create Options: %#v", repo)
+	newRepo, err := config.cobblerClient.CreateRepo(repo)
+	if err != nil {
+		return fmt.Errorf("Cobbler Repo: Error Creating: %s", err)
+	}
+
+	d.SetId(newRepo.Name)
+
+	return resourceRepoRead(d, meta)
+}
+
+func resourceRepoRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	// Retrieve the repo from cobbler
+	repo, err := config.cobblerClient.GetRepo(d.Id())
+	if err != nil {
+		return fmt.Errorf("Cobbler Repo: Error Reading (%s): %s", d.Id(), err)
+	}
+
+	// Set all fields
+	d.Set("apt_components", repo.AptComponents)
+	d.Set("apt_dists", repo.AptDists)
+	d.Set("arch", repo.Arch)
+	d.Set("breed", repo.Breed)
+	d.Set("comment", repo.Comment)
+	d.Set("createrepo_flags", repo.CreateRepoFlags)
+	d.Set("environment", repo.Environment)
+	d.Set("keep_updated", repo.KeepUpdated)
+	d.Set("mirror", repo.Mirror)
+	d.Set("mirror_locally", repo.MirrorLocally)
+	d.Set("name", repo.Name)
+	d.Set("owners", repo.Owners)
+	d.Set("proxy", repo.Proxy)
+	d.Set("rpm_list", repo.RpmList)
+	d.Set("yumopts", repo.YumOpts)
+
+	return nil
+}
+
+func resourceRepoUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	// create a cobblerclient.Repo
+	repo := buildRepo(d, config)
+
+	// Attempt to updateh the repo with new information
+	log.Printf("[DEBUG] Cobbler Repo: Updating Repo (%s) with options: %+v", d.Id(), repo)
+	err := config.cobblerClient.UpdateRepo(&repo)
+	if err != nil {
+		return fmt.Errorf("Cobbler Repo: Error Updating (%s): %s", d.Id(), err)
+	}
+
+	return resourceRepoRead(d, meta)
+}
+
+func resourceRepoDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	// Attempt to delete the repo
+	if err := config.cobblerClient.DeleteRepo(d.Id()); err != nil {
+		return fmt.Errorf("Cobbler Repo: Error Deleting (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+// buildRepo builds a cobbler.Repo from the Terraform attributes
+func buildRepo(d *schema.ResourceData, meta interface{}) cobbler.Repo {
+	aptComponents := []string{}
+	for _, i := range d.Get("apt_components").([]interface{}) {
+		aptComponents = append(aptComponents, i.(string))
+	}
+
+	aptDists := []string{}
+	for _, i := range d.Get("apt_dists").([]interface{}) {
+		aptDists = append(aptDists, i.(string))
+	}
+
+	owners := []string{}
+	for _, i := range d.Get("owners").([]interface{}) {
+		owners = append(owners, i.(string))
+	}
+
+	rpmList := []string{}
+	for _, i := range d.Get("rpm_list").([]interface{}) {
+		rpmList = append(rpmList, i.(string))
+	}
+
+	yumOpts := []string{}
+	for _, i := range d.Get("yum_opts").([]interface{}) {
+		yumOpts = append(yumOpts, i.(string))
+	}
+
+	repo := cobbler.Repo{
+		AptComponents:   aptComponents,
+		AptDists:        aptDists,
+		Arch:            d.Get("arch").(string),
+		Breed:           d.Get("breed").(string),
+		Comment:         d.Get("comment").(string),
+		CreateRepoFlags: d.Get("createrepo_flags").(string),
+		Environment:     d.Get("environment").(string),
+		KeepUpdated:     d.Get("keep_updated").(bool),
+		Mirror:          d.Get("mirror").(string),
+		MirrorLocally:   d.Get("mirror_locally").(bool),
+		Name:            d.Get("name").(string),
+		Owners:          owners,
+		Proxy:           d.Get("proxy").(string),
+		RpmList:         rpmList,
+		YumOpts:         yumOpts,
+	}
+
+	return repo
+}

--- a/cobbler/resource_cobbler_repo_test.go
+++ b/cobbler/resource_cobbler_repo_test.go
@@ -1,0 +1,129 @@
+package cobbler
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	cobbler "github.com/jtopjian/cobblerclient"
+)
+
+func TestAccCobblerRepo_basic(t *testing.T) {
+	var repo cobbler.Repo
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccCobblerPreCheck(t) },
+		Providers:    testAccCobblerProviders,
+		CheckDestroy: testAccCobblerCheckRepoDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCobblerRepo_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCobblerCheckRepoExists(t, "cobbler_repo.foo", &repo),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCobblerRepo_change(t *testing.T) {
+	var repo cobbler.Repo
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccCobblerPreCheck(t) },
+		Providers:    testAccCobblerProviders,
+		CheckDestroy: testAccCobblerCheckRepoDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCobblerRepo_change_1,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCobblerCheckRepoExists(t, "cobbler_repo.foo", &repo),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCobblerRepo_change_2,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCobblerCheckRepoExists(t, "cobbler_repo.foo", &repo),
+				),
+			},
+		},
+	})
+}
+
+func testAccCobblerCheckRepoDestroy(s *terraform.State) error {
+	config := testAccCobblerProvider.Meta().(*Config)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "cobbler_repo" {
+			continue
+		}
+
+		if _, err := config.cobblerClient.GetRepo(rs.Primary.ID); err == nil {
+			return fmt.Errorf("Repo still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCobblerCheckRepoExists(t *testing.T, n string, repo *cobbler.Repo) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccCobblerProvider.Meta().(*Config)
+
+		found, err := config.cobblerClient.GetRepo(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if found.Name != rs.Primary.ID {
+			return fmt.Errorf("Repo not found")
+		}
+
+		*repo = *found
+
+		return nil
+	}
+}
+
+var testAccCobblerRepo_basic = `
+  resource "cobbler_repo" "foo" {
+    name = "foo"
+    breed = "apt"
+    arch = "x86_64"
+    apt_components = ["main"]
+    apt_dists = ["trusty"]
+    mirror = "http://us.archive.ubuntu.com/ubuntu/"
+  }`
+
+var testAccCobblerRepo_change_1 = `
+  resource "cobbler_repo" "foo" {
+    name = "foo"
+    comment = "I am a repo"
+    breed = "apt"
+    arch = "x86_64"
+    apt_components = ["main"]
+    apt_dists = ["trusty"]
+    mirror = "http://us.archive.ubuntu.com/ubuntu/"
+  }`
+
+var testAccCobblerRepo_change_2 = `
+  resource "cobbler_repo" "foo" {
+    name = "foo"
+    comment = "I am a repo again"
+    breed = "apt"
+    arch = "x86_64"
+    apt_components = ["main"]
+    apt_dists = ["trusty"]
+    mirror = "http://us.archive.ubuntu.com/ubuntu/"
+  }`


### PR DESCRIPTION
When defining a profile with repos that do not exist, an error will be returned. To enable full automation of a Cobbler server's setup, support for setting up repos has been added.

This is dependent on the merging of https://github.com/jtopjian/cobblerclient/pull/3.