### PR TITLE
SSL Support

### DIFF
--- a/cobbler/provider.go
+++ b/cobbler/provider.go
@@ -30,6 +30,20 @@ func Provider() terraform.ResourceProvider {
 				Description: "The password for accessing Cobbler.",
 				DefaultFunc: envDefaultFunc("COBBLER_PASSWORD"),
 			},
+
+			"insecure": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: envDefaultFunc("COBBLER_INSECURE"),
+				Description: "Ignore SSL certificate warnings and errors.",
+			},
+
+			"cacert_file": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: envDefaultFunc("COBBLER_CACERT"),
+				Description: "The path or contents of an SSL CA certificate",
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -47,9 +61,11 @@ func Provider() terraform.ResourceProvider {
 
 func configureProvider(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
-		Url:      d.Get("url").(string),
-		Username: d.Get("username").(string),
-		Password: d.Get("password").(string),
+		CACertFile: d.Get("cacert_file").(string),
+		Insecure:   d.Get("insecure").(bool),
+		Url:        d.Get("url").(string),
+		Username:   d.Get("username").(string),
+		Password:   d.Get("password").(string),
 	}
 
 	if err := config.loadAndValidate(); err != nil {

--- a/cobbler/provider.go
+++ b/cobbler/provider.go
@@ -41,7 +41,7 @@ func Provider() terraform.ResourceProvider {
 			"cacert_file": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: envDefaultFunc("COBBLER_CACERT"),
+				DefaultFunc: envDefaultFunc("COBBLER_CACERT_FILE"),
 				Description: "The path or contents of an SSL CA certificate",
 			},
 		},

--- a/vendor/github.com/hashicorp/terraform/helper/pathorcontents/read.go
+++ b/vendor/github.com/hashicorp/terraform/helper/pathorcontents/read.go
@@ -1,0 +1,40 @@
+// Helpers for dealing with file paths and their contents
+package pathorcontents
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/mitchellh/go-homedir"
+)
+
+// If the argument is a path, Read loads it and returns the contents,
+// otherwise the argument is assumed to be the desired contents and is simply
+// returned.
+//
+// The boolean second return value can be called `wasPath` - it indicates if a
+// path was detected and a file loaded.
+func Read(poc string) (string, bool, error) {
+	if len(poc) == 0 {
+		return poc, false, nil
+	}
+
+	path := poc
+	if path[0] == '~' {
+		var err error
+		path, err = homedir.Expand(path)
+		if err != nil {
+			return path, true, err
+		}
+	}
+
+	if _, err := os.Stat(path); err == nil {
+		contents, err := ioutil.ReadFile(path)
+		if err != nil {
+			return string(contents), true, err
+		}
+		return string(contents), true, nil
+	}
+
+	return poc, false, nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -454,6 +454,12 @@
 			"versionExact": "v0.10.0"
 		},
 		{
+			"checksumSHA1": "ImyqbHM/xe3eAT2moIjLI8ksuks=",
+			"path": "github.com/hashicorp/terraform/helper/pathorcontents",
+			"revision": "0e69f1542dcbd39c6e5b3327916fc7b70dcdc70b",
+			"revisionTime": "2018-01-11T18:50:06Z"
+		},
+		{
 			"checksumSHA1": "dhU2woQaSEI2OnbYLdkHxf7/nu8=",
 			"path": "github.com/hashicorp/terraform/helper/resource",
 			"revision": "2041053ee9444fa8175a298093b55a89586a1823",

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -43,3 +43,7 @@ The following arguments are supported:
 
 * `url` - (Required) The url to the Cobbler service. This can
   also be specified with the `COBBLER_URL` shell environment variable.
+
+* `insecure` - (Optional) Ignore SSL certificate warnings and errors.
+
+* `cacert_file` - (Optional) The path or contents of an SSL CA certificate.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -44,6 +44,9 @@ The following arguments are supported:
 * `url` - (Required) The url to the Cobbler service. This can
   also be specified with the `COBBLER_URL` shell environment variable.
 
-* `insecure` - (Optional) Ignore SSL certificate warnings and errors.
+* `insecure` - (Optional) Ignore SSL certificate warnings and errors. This
+  can also be specified with the `COBBLER_INSECURE` shell environment variable.
 
 * `cacert_file` - (Optional) The path or contents of an SSL CA certificate.
+  This can also be specified with the `COBBLER_CACERT_FILE` shell environment
+  variable.


### PR DESCRIPTION
This commit adds options to help with SSL connectivity:

* insecure: ignore SSL warnings and errors. useful for self-signed certs.
* cacert_file: specify the path or contents of a ca certificate.