### PR TITLE
Recreate Missing Systems

### DIFF
--- a/cobbler/resource_cobbler_system.go
+++ b/cobbler/resource_cobbler_system.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"strings"
 	"sync"
 
 	"github.com/hashicorp/terraform/helper/hashcode"
@@ -462,6 +463,12 @@ func resourceSystemRead(d *schema.ResourceData, meta interface{}) error {
 	// Retrieve the system entry from Cobbler
 	system, err := config.cobblerClient.GetSystem(d.Id())
 	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			log.Printf("[WARN] Cobbler System (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+
 		return fmt.Errorf("Cobbler System: Error Reading (%s): %s", d.Id(), err)
 	}
 


### PR DESCRIPTION
This commit will enable Terraform to recreate systems when
they have been deleted/removed from Cobbler outside of Terraform.

Fixes #13 