### PR TITLE
provider: Improve error message for login failures

### DIFF
--- a/cobbler/config.go
+++ b/cobbler/config.go
@@ -54,7 +54,7 @@ func (c *Config) loadAndValidate() error {
 	client := cobbler.NewClient(httpClient, config)
 	_, err := client.Login()
 	if err != nil {
-		return err
+		return fmt.Errorf("Failed to login: %s", err)
 	}
 
 	c.cobblerClient = client


### PR DESCRIPTION
When the endpoint isn't set up properly the SDK may return errors like `EOF` which are hard to understand.